### PR TITLE
Added tmux and replaced `hub` with official `gh` Github CLI

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -40,9 +40,10 @@ stable.mkShell {
     stable.gnupg
     stable.pgcli
     stable.gitAndTools.gitFull
-    stable.gitAndTools.hub
+    stable.tmux
 
     latest.heroku
+    latest.gh
   ];
 }
 


### PR DESCRIPTION
@dylanpyle You asked about `tmux` and I know @mendrew also uses this, so I'm assigning you here.

Also swapped `hub` for `gh` since it seems like `gh` being official is a good reason to prefer it. Here's a comparison: https://github.com/cli/cli/blob/trunk/docs/gh-vs-hub.md

FYI: If anyone want to ever PR adding a new package, here is how you can search: https://search.nixos.org/packages (!nixpkgs on duckduckgo if you use that). You can compare versions between `20.09` and `unstable` to decide between our `stable` and `latest` branches. We pin both references to the package registry, so `latest` won't be _perfectly_ aligned with version you see on the `unstable` branch, but it'll give you an idea of how far behind `stable` is.