### PR TITLE
Update instructions for nix 2.4 stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mkdir -p ~/.config/nix
 cat > ~/.config/nix/nix.conf<< EOF
 system = aarch64-darwin
 extra-platforms = x86_64-darwin
+experimental-features = nix-command flakes
 EOF
 
 # Initial setup of CALA nix repo


### PR DESCRIPTION
The unstable version of `nix` that we've been using has been stabilized, and the latest installer doesn't require any macOS specific changes 🎉 