### PR TITLE
Use aarch64-darwin when possible

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1618217525,
-        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {
@@ -15,43 +15,43 @@
         "type": "github"
       }
     },
-    "nixpkgs-latest": {
+    "nixpkgs": {
       "locked": {
-        "lastModified": 1618260938,
-        "narHash": "sha256-sRIKbJKplnAY9uN4QGGVtq4dasRKzmZhjleCUtPvTa8=",
+        "lastModified": 1636333654,
+        "narHash": "sha256-3wh9PtCzcaJQuZrgZ+ygKfhltkDNNqT6zOzGsRbjZEo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8893cc489de8ffbe8125fb0d37f05e8023a2d99",
+        "rev": "e74894146a42ba552ebafa19ab2d1df7ccbc1738",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixpkgs-21.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs-intel": {
       "locked": {
-        "lastModified": 1612817315,
-        "narHash": "sha256-PfadbCHb63WBTdb+7AosgzOWkimPKNETcOIRn+bP/aU=",
-        "owner": "NixOs",
+        "lastModified": 1617769200,
+        "narHash": "sha256-AjM4hXp/QOPftocbF+xMPzWTh2fRbU+Ct9IFKKX9XSc=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bed08131cd29a85f19716d9351940bdc34834492",
+        "rev": "bfd326421ef093b77d70dfe8b9195e1cee78c097",
         "type": "github"
       },
       "original": {
-        "owner": "NixOs",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bed08131cd29a85f19716d9351940bdc34834492",
+        "rev": "bfd326421ef093b77d70dfe8b9195e1cee78c097",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs-latest": "nixpkgs-latest",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-intel": "nixpkgs-intel"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,21 @@
 {
   description = "A CALA development environment";
 
-  inputs.nixpkgs-latest.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nixpkgs-stable.url = "github:NixOs/nixpkgs?rev=bed08131cd29a85f19716d9351940bdc34834492";
+  inputs.nixpkgs-intel.url = "github:NixOS/nixpkgs/bfd326421ef093b77d70dfe8b9195e1cee78c097";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-21.05-darwin";
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
     inputs.nixpkgs.follows = "nixpkgs-latest";
   };
 
-  outputs = { self, nixpkgs-latest, nixpkgs-stable, flake-utils }:
-    flake-utils.lib.eachSystem (flake-utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
+  outputs = { self, nixpkgs, nixpkgs-intel, flake-utils }:
+    flake-utils.lib.eachSystem (flake-utils.lib.defaultSystems) (system:
       let
-        nodejs = nixpkgs-latest.legacyPackages.x86_64-darwin.nodejs-14_x;
-        yarn = nixpkgs-latest.legacyPackages.x86_64-darwin.yarn;
-        postgresql = nixpkgs-latest.legacyPackages.x86_64-darwin.postgresql_13;
+        pkgs = nixpkgs.legacyPackages.${system};
+        intel = nixpkgs-intel.legacyPackages.x86_64-darwin;
+        nodejs = intel.nodejs-14_x;
+        yarn = intel.yarn;
+        postgresql = intel.postgresql_13;
         config = {
           elasticmq = {
             queues = ''
@@ -41,26 +43,25 @@
             '';
           };
         };
-        elasticmq = (import ./elasticmq.nix) { inherit config; pkgs =
-nixpkgs-stable.legacyPackages.x86_64-darwin; };
+        elasticmq = (import ./elasticmq.nix) { inherit config pkgs; };
       in {
-        devShell = nixpkgs-latest.legacyPackages.x86_64-darwin.mkShell {
+        devShell = pkgs.mkShell {
           buildInputs = [
             nodejs
             yarn
             postgresql
             elasticmq
 
-            nixpkgs-stable.legacyPackages.x86_64-darwin.findutils
-            nixpkgs-stable.legacyPackages.x86_64-darwin.jq
-            nixpkgs-stable.legacyPackages.x86_64-darwin.pandoc
-            nixpkgs-stable.legacyPackages.x86_64-darwin.gnupg
-            nixpkgs-stable.legacyPackages.x86_64-darwin.pgcli
-            nixpkgs-stable.legacyPackages.x86_64-darwin.gitAndTools.gitFull
-            nixpkgs-stable.legacyPackages.x86_64-darwin.tmux
+            pkgs.findutils
+            pkgs.jq
+            intel.pandoc
+            pkgs.gnupg
+            pkgs.pgcli
+            pkgs.gitAndTools.git
+            pkgs.tmux
 
-            nixpkgs-latest.legacyPackages.x86_64-darwin.heroku
-            nixpkgs-latest.legacyPackages.x86_64-darwin.gh
+            pkgs.heroku
+            pkgs.gh
           ];
         };
       });


### PR DESCRIPTION
Update to use `aarch64-darwin` in all of the places we can, while keeping `node`, `yarn`, and `Postgres` on the same version we had before.

We should consider bumping to newer versions of those packages, too, since they're now being built for `aarch64-darwin`, but that's a separate effort that would want to update this in a bunch of places, including in production, so I kept them the same for now.