### PR TITLE
Add AWS CLI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636333654,
-        "narHash": "sha256-3wh9PtCzcaJQuZrgZ+ygKfhltkDNNqT6zOzGsRbjZEo=",
+        "lastModified": 1666014999,
+        "narHash": "sha256-gvKl8xlPJreezNG1NVTJv/HdGC69MSrM+IpCxS+eFvw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e74894146a42ba552ebafa19ab2d1df7ccbc1738",
+        "rev": "1935dd8fdab8e022a9d958419663162fd840014c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
+        "ref": "nixpkgs-22.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,6 @@
         pkgs = nixpkgs.legacyPackages.${system};
         intel = nixpkgs-intel.legacyPackages.x86_64-darwin;
         nodejs = intel.nodejs-14_x;
-        yarn = intel.yarn;
-        postgresql = intel.postgresql_13;
         config = {
           elasticmq = {
             queues = ''
@@ -48,13 +46,13 @@
         devShell = pkgs.mkShell {
           buildInputs = [
             nodejs
-            yarn
-            postgresql
             elasticmq
+            pkgs.postgresql_13
+            pkgs.yarn
 
             pkgs.findutils
             pkgs.jq
-            intel.pandoc
+            pkgs.pandoc
             pkgs.gnupg
             pkgs.pgcli
             pkgs.gitAndTools.git

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A CALA development environment";
 
   inputs.nixpkgs-intel.url = "github:NixOS/nixpkgs/bfd326421ef093b77d70dfe8b9195e1cee78c097";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-21.05-darwin";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-22.05-darwin";
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
     inputs.nixpkgs.follows = "nixpkgs-latest";

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
 
             pkgs.heroku
             pkgs.gh
+            pkgs.awscli2
           ];
         };
       });


### PR DESCRIPTION
- Bumps to the latest stable version of the nixpkgs repository
- Use the native ARM packages for most things since they are now available
- Add the AWS CLI

Note: I tried just adding the AWS CLI, but it failed when trying to build GCC (😱 ) probably due to trying to get some rosetta stuff working. That was enough for me to just bump the whole shebang and get more ARM packages.

The only notable change here is PostgreSQL which goes from 13.2 -> 13.8. We really need to migrate our local instances to 14 to match Production anyway, but this isn't really a big deal.