### PR TITLE
Bump postgres version to 14

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
           buildInputs = [
             nodejs
             elasticmq
-            pkgs.postgresql_13
+            pkgs.postgresql_14
             pkgs.yarn
 
             pkgs.findutils


### PR DESCRIPTION
I was getting the following error while trying to run `bin/bootstrap` script from the [api](https://github.com/ca-la/api) repo:

```
Downloading pricing data from Staging...  ›   Warning: heroku update available from 7.59.2 to 7.65.0.
pg_dump: error: server version: 14.5 (Ubuntu 14.5-2.pgdg20.04+2); pg_dump version: 13.8
pg_dump: error: aborting because of server version mismatch
```

Seemed like the staging Postgres is using a newer version that is incompatible with the version installed by Nix.

Here I've bumped the Postgres version to 14, after doing it the version mismatch was gone.